### PR TITLE
Added pre-receive-app and pre-destroy hooks

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
 description = "dokku plugin that can be used to restrict push privileges for app to certain users"
-version = "1.0.0"
+version = "1.0.1"
 [plugin.config]

--- a/pre-build
+++ b/pre-build
@@ -7,7 +7,7 @@ DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
 
 if [[ ! -d "$ACL" ]]; then
   if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-    echo "Only $DOKKU_SUPER_USER can push if the ACL is empty" >&2;
+    echo "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty" >&2;
     exit 1;
   fi;
 
@@ -17,6 +17,6 @@ fi
 ACL_FILE="$ACL/$NAME"
 
 if [[ ! -f "$ACL_FILE" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-  echo "User $NAME does not have permissions to push to this repository" >&2
+  echo "User $NAME does not have permissions to modify this repository" >&2
   exit 2;
 fi

--- a/pre-delete
+++ b/pre-delete
@@ -1,0 +1,1 @@
+pre-build

--- a/pre-receive-app
+++ b/pre-receive-app
@@ -1,0 +1,1 @@
+pre-build


### PR DESCRIPTION
Unauthorized users should not be allowed to destroy apps or push to them. Adding pre-receive-app probably makes pre-build-buildstep redundant.
