### PR TITLE
Add default command

### DIFF
--- a/commands
+++ b/commands
@@ -85,7 +85,7 @@ case "${1:-}" in
     help_content_func
   else
     cat<<help_desc
-    acl, Plugin for adding the ability to restrict push privileges for app to certain users
+    acl, Plugin to manage app-level Access Control Lists
 help_desc
   fi
     ;;

--- a/commands
+++ b/commands
@@ -4,6 +4,8 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 set -u
 
+source "$PLUGIN_AVAILABLE_PATH/acl/functions"
+
 APP=${2:-}
 ACL_PATH="$DOKKU_ROOT/$APP/acl"
 
@@ -77,18 +79,8 @@ case "${1:-}" in
     [ -n "$APP" ] && ls -1 "$DOKKU_ROOT/$APP/acl" >&2  2>/dev/null;
     ;;
   help | acl:help)
-  help_content_func() {
-    cat<<help_content
-    acl:add <app> <user>, Allow user to push to this repository
-    acl:remove <app> <user>, Revoke users access to the repository
-    acl:list <app>, Show list of users with access to repository
-help_content
-  }
   if [[ $1 = "acl:help" ]] ; then
-    echo -e "Usage: dokku acl:[:COMMAND]"
-    echo ''
-    echo 'Commands:'
-    help_content_func | sort | column -c2 -t -s,
+    help_formatted
   elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
     help_content_func
   else

--- a/functions
+++ b/functions
@@ -1,0 +1,14 @@
+help_formatted() {
+  echo -e "Usage: dokku acl[:COMMAND]"
+  echo ''
+  echo 'Commands:'
+  help_content_func | sort | column -c2 -t -s,
+}
+
+help_content_func() {
+  cat<<help_content
+  acl:add <app> <user>, Allow user to push to this repository
+  acl:remove <app> <user>, Revoke users access to the repository
+  acl:list <app>, Show list of users with access to repository
+help_content
+}

--- a/functions
+++ b/functions
@@ -1,7 +1,9 @@
 help_formatted() {
   echo -e "Usage: dokku acl[:COMMAND]"
   echo ''
-  echo 'Commands:'
+  echo 'Manage app-level Access Control Lists.'
+  echo ''
+  echo 'Additional commands:'
   help_content_func | sort | column -c2 -t -s,
 }
 

--- a/functions
+++ b/functions
@@ -9,8 +9,8 @@ help_formatted() {
 
 help_content_func() {
   cat<<help_content
-  acl:add <app> <user>, Allow user to push to this repository
-  acl:remove <app> <user>, Revoke users access to the repository
-  acl:list <app>, Show list of users with access to repository
+  acl:add <app> <user>, Allow <user> to push to <app>'s repository
+  acl:remove <app> <user>, Revoke <user>'s access to <app>'s repository
+  acl:list <app>, Show list of users with access to <app>'s repository
 help_content
 }

--- a/subcommands/default
+++ b/subcommands/default
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+source "$PLUGIN_AVAILABLE_PATH/acl/functions"
+
+acl_main_cmd() {
+  declare desc="display acl plugin help content"
+  local cmd="acl"
+  help_formatted
+}
+
+acl_main_cmd "$@"

--- a/tests/commands.bats
+++ b/tests/commands.bats
@@ -54,6 +54,10 @@ teardown() {
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:default) help information is shown by default" {
+  if [[ $DOKKU_VERSION = 'v0.4.0' ]] ; then
+    skip "Default commands weren't implemented for v0.4.0"
+  fi
+
   run dokku acl:help
   help_output="$output"
   assert_success

--- a/tests/commands.bats
+++ b/tests/commands.bats
@@ -52,3 +52,12 @@ teardown() {
   assert_equal ${lines[0]} "user1"
   assert_equal ${lines[1]} "user2"
 }
+
+@test "($PLUGIN_COMMAND_PREFIX:default) help information is shown by default" {
+  run dokku acl:help
+  help_output="$output"
+  assert_success
+
+  run dokku acl
+  assert_success "$help_output"
+}


### PR DESCRIPTION
Add a default command that displays help. Fixes #8.

@bpostlethwaite Please review.

```
root@dokku:~# dokku acl
Usage: dokku acl[:COMMAND]

Commands:
  acl:add <app> <user>      Allow user to push to this repository
  acl:list <app>            Show list of users with access to repository
  acl:remove <app> <user>   Revoke users access to the repository
```