### PR TITLE
Fix commandline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ Every user has their entry in `~dokku/.ssh/authorized_keys`. Use
 `$NAME` environment variable to define the username. If you add the user
 using `dokku ssh-keys:add`, this will be done automatically for you.
 
+### configuring command line usage
+
+By default, certain dokku commands (e.g. `app:destroy`) won't work when run
+from the command line on the server, if `DOKKU_SUPER_USER` is set, even when
+run as `root` or `dokku`. To avoid confusion, we recommend allowing command
+line access by defining `DOKKU_ACL_ALLOW_COMMAND_LINE` in
+`~dokku/.dokkurc/acl`:
+
+```shell
+export DOKKU_ACL_ALLOW_COMMAND_LINE=1
+```
+
+(The default behaviour exists to prevent security issues for users who were
+depending on the legacy behaviour. We recommend that all users set the
+variable above.)
+
 ### default behavior
 
 By default every user can push to repositories and even create new ones. You can change that by creating an admin

--- a/pre-build
+++ b/pre-build
@@ -4,20 +4,25 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1";
 ACL="$DOKKU_ROOT/$APP/acl"
 DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
+DOKKU_ACL_ALLOW_COMMAND_LINE="${DOKKU_ACL_ALLOW_COMMAND_LINE:-}"
 
 if [[ -z "$NAME" ]] ; then
   # Command line usage doesn't set $NAME.
 
-  # Preserve legacy behaviour by default for safety, even though it's weird.
+  if [[ -z "$DOKKU_ACL_ALLOW_COMMAND_LINE" ]] ; then
+    # Preserve legacy behaviour by default for safety, even though it's weird.
 
-  [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
+    [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
 
-  echo -n "It appears that you're running this command from the command "
-  echo -n "line.  The \"dokku-acl\" plugin disables this by default for "
-  echo -n "safety.  Please check the \"dokku-acl\" documentation for how "
-  echo -n "to enable command line usage."
+    echo -n "It appears that you're running this command from the command "
+    echo -n "line.  The \"dokku-acl\" plugin disables this by default for "
+    echo -n "safety.  Please check the \"dokku-acl\" documentation for how "
+    echo -n "to enable command line usage."
 
-  exit 1
+    exit 1
+  fi
+
+  exit 0
 fi
 
 if [[ ! -d "$ACL" ]]; then

--- a/pre-build
+++ b/pre-build
@@ -17,7 +17,7 @@ if [[ -z "$NAME" ]] ; then
     echo -n "It appears that you're running this command from the command "
     echo -n "line.  The \"dokku-acl\" plugin disables this by default for "
     echo -n "safety.  Please check the \"dokku-acl\" documentation for how "
-    echo -n "to enable command line usage."
+    echo "to enable command line usage."
 
     exit 1
   fi

--- a/pre-build
+++ b/pre-build
@@ -5,6 +5,21 @@ APP="$1";
 ACL="$DOKKU_ROOT/$APP/acl"
 DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
 
+if [[ -z "$NAME" ]] ; then
+  # Command line usage doesn't set $NAME.
+
+  # Preserve legacy behaviour by default for safety, even though it's weird.
+
+  [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
+
+  echo -n "It appears that you're running this command from the command "
+  echo -n "line.  The \"dokku-acl\" plugin disables this by default for "
+  echo -n "safety.  Please check the \"dokku-acl\" documentation for how "
+  echo -n "to enable command line usage."
+
+  exit 1
+fi
+
 if [[ ! -d "$ACL" ]]; then
   if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
     echo "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty" >&2;

--- a/tests/hook_pre_build.bats
+++ b/tests/hook_pre_build.bats
@@ -99,3 +99,30 @@ teardown() {
   run $HOOK $APP
   assert_failure "It appears that you're running this command from the command line.  The \"dokku-acl\" plugin disables this by default for safety.  Please check the \"dokku-acl\" documentation for how to enable command line usage."
 }
+
+@test "($PLUGIN_COMMAND_PREFIX:hook-pre-build) allows command line usage when DOKKU_ACL_ALLOW_COMMAND_LINE set" {
+  unset NAME
+  export DOKKU_ACL_ALLOW_COMMAND_LINE=1
+
+  # No app ACL, no DOKKU_SUPER_USER -> success
+  run $HOOK $APP
+  assert_success
+
+  # No app ACL, DOKKU_SUPER_USER set -> success
+  export DOKKU_SUPER_USER=admin
+
+  run $HOOK $APP
+  assert_success
+
+  # App ACL exists, no DOKKU_SUPER_USER -> success
+  unset DOKKU_SUPER_USER
+  sudo -u dokku mkdir -p $APP_DIR/acl
+  sudo -u dokku touch $APP_DIR/acl/user1
+
+  run $HOOK $APP
+  assert_success
+
+  # App ACL exists, DOKKU_SUPER_USER set -> success
+  run $HOOK $APP
+  assert_success
+}

--- a/tests/hook_pre_build.bats
+++ b/tests/hook_pre_build.bats
@@ -74,10 +74,10 @@ teardown() {
   export DOKKU_SUPER_USER=admin
 
   SSH_NAME=default run $HOOK $APP
-  assert_failure "Only admin can modify a repository if the ACL is empty"
+  assert_failure "It appears that you're running this command from the command line.  The \"dokku-acl\" plugin disables this by default for safety.  Please check the \"dokku-acl\" documentation for how to enable command line usage."
 
   run $HOOK $APP
-  assert_failure "Only admin can modify a repository if the ACL is empty"
+  assert_failure "It appears that you're running this command from the command line.  The \"dokku-acl\" plugin disables this by default for safety.  Please check the \"dokku-acl\" documentation for how to enable command line usage."
 
   # App ACL exists, no DOKKU_SUPER_USER -> success
   unset DOKKU_SUPER_USER
@@ -94,8 +94,8 @@ teardown() {
   export DOKKU_SUPER_USER=admin
 
   SSH_NAME=default run $HOOK $APP
-  assert_failure "User  does not have permissions to modify this repository"
+  assert_failure "It appears that you're running this command from the command line.  The \"dokku-acl\" plugin disables this by default for safety.  Please check the \"dokku-acl\" documentation for how to enable command line usage."
 
   run $HOOK $APP
-  assert_failure "User  does not have permissions to modify this repository"
+  assert_failure "It appears that you're running this command from the command line.  The \"dokku-acl\" plugin disables this by default for safety.  Please check the \"dokku-acl\" documentation for how to enable command line usage."
 }


### PR DESCRIPTION
Fixes #5.

As discussed at https://github.com/dokku-community/dokku-acl/issues/5#issuecomment-290549276 , legacy behaviour is preserved by default. The difference is it's now possible to override this, and the documentation recommends doing so.

@josegonzalez @bpostlethwaite Please review.