### PR TITLE
Send all errors to STDERR

### DIFF
--- a/commands
+++ b/commands
@@ -2,6 +2,9 @@
 
 [[ " help acl:help " == *" $1 "* ]] || [[ "$1" == "acl:"* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
 set -u
 
 source "$PLUGIN_AVAILABLE_PATH/acl/functions"
@@ -14,20 +17,17 @@ check_app() {
 
   if [ -z "$app" ];
   then
-    echo "You must provide an app name!" >&2
-    exit;
+    dokku_log_fail "You must provide an app name!"
   fi
 
   if [ ! -d "$DOKKU_ROOT/$app" ];
   then
-    echo "No such app: $app" >&2
-    exit;
+    dokku_log_fail "No such app: $app"
   fi
 
   if [ -n "${NAME:-}" ];
   then
-    echo "You can only modify ACL using local dokku command on target host" >&2
-    exit;
+    dokku_log_fail "You can only modify ACL using local dokku command on target host"
   fi
 }
 
@@ -39,8 +39,7 @@ case "${1:-}" in
 
     if [ -z "$USER" ];
     then
-      echo "Please specify a user name" >&2
-      exit 1;
+      dokku_log_fail "Please specify a user name"
     fi
 
     [ ! -d "$ACL_PATH" ] && mkdir "$ACL_PATH";
@@ -48,7 +47,7 @@ case "${1:-}" in
     ACL_FILE="$ACL_PATH/$USER"
     if [ -f "$ACL_FILE" ];
     then
-       echo "User already has permissions to push to this repository"
+       echo "User already has permissions to push to this repository" >&2
        exit 2;
     fi
     touch "$ACL_FILE"
@@ -59,8 +58,7 @@ case "${1:-}" in
 
     if [ -z "$USER" ];
     then
-      echo "Please specify a user name" >&2
-      exit 1;
+      dokku_log_fail "Please specify a user name"
     fi
 
     ACL_FILE="$ACL_PATH/"$(basename "$USER");

--- a/commands
+++ b/commands
@@ -9,29 +9,26 @@ source "$PLUGIN_AVAILABLE_PATH/acl/functions"
 APP=${2:-}
 ACL_PATH="$DOKKU_ROOT/$APP/acl"
 
-check_app () {
-  if [ -z "$1" ];
+check_app() {
+  declare app="$1"
+
+  if [ -z "$app" ];
   then
     echo "You must provide an app name!" >&2
-    echo 1;
     exit;
   fi
 
-  if [ ! -d "$DOKKU_ROOT/$1" ];
+  if [ ! -d "$DOKKU_ROOT/$app" ];
   then
-    echo "No such app: $1" >&2
-    echo 2;
+    echo "No such app: $app" >&2
     exit;
   fi
 
   if [ -n "${NAME:-}" ];
   then
     echo "You can only modify ACL using local dokku command on target host" >&2
-    echo 3;
     exit;
   fi
-
-  echo 0
 }
 
 check_admin () {
@@ -40,7 +37,7 @@ check_admin () {
 
 case "${1:-}" in
   acl:add)
-    test "$(check_app "$APP")" -eq 0;
+    check_app "$APP"
 
     USER=${3:-}
 
@@ -61,7 +58,7 @@ case "${1:-}" in
     touch "$ACL_FILE"
     ;;
   acl:remove)
-    test "$(check_app "$APP")" -eq 0;
+    check_app "$APP"
     USER=${3:-}
 
     if [ -z "$USER" ];

--- a/commands
+++ b/commands
@@ -31,10 +31,6 @@ check_app() {
   fi
 }
 
-check_admin () {
-  echo 1
-}
-
 case "${1:-}" in
   acl:add)
     check_app "$APP"

--- a/pre-build
+++ b/pre-build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
 APP="$1";
 ACL="$DOKKU_ROOT/$APP/acl"
@@ -14,12 +15,10 @@ if [[ -z "$NAME" ]] ; then
 
     [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
 
-    echo -n "It appears that you're running this command from the command "
-    echo -n "line.  The \"dokku-acl\" plugin disables this by default for "
-    echo -n "safety.  Please check the \"dokku-acl\" documentation for how "
-    echo "to enable command line usage."
-
-    exit 1
+    dokku_log_fail "It appears that you're running this command from the command" \
+      "line.  The \"dokku-acl\" plugin disables this by default for" \
+      "safety.  Please check the \"dokku-acl\" documentation for how" \
+      "to enable command line usage."
   fi
 
   exit 0
@@ -27,8 +26,7 @@ fi
 
 if [[ ! -d "$ACL" ]]; then
   if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-    echo "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty" >&2;
-    exit 1;
+    dokku_log_fail "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty"
   fi;
 
   exit 0; # all good, there are no restrictions

--- a/user-auth
+++ b/user-auth
@@ -27,23 +27,19 @@ done
 for allowed in $DOKKU_ACL_PER_APP_COMMANDS; do
   if [[ "$CMD" == "$allowed" ]]; then
     if [[ -z "$2" ]]; then
-      echo "An app name is required"
-      exit 1
+      dokku_log_fail "An app name is required"
     fi
 
     APP=$2
     if ! ( verify_app_name "$APP" 2>/dev/null ); then
-      echo "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist" >&2
-      exit 1
+      dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
     fi
 
     ACL_FILE="$DOKKU_ROOT/$APP/acl/$SSH_NAME"
     [[ -f "$ACL_FILE" ]] && exit 0
 
-    echo "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist" >&2
-    exit 1
+    dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
   fi
 done
 
-echo "User $SSH_NAME does not have permissions to run $CMD"
-exit 1
+dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD"


### PR DESCRIPTION
This makes all errors go to STDOUT consistently, and future-proofs us if Dokku adds fancier error handling later.

@bpostlethwaite Please review.
@josegonzalez Feel free to take a look if you like.