### PR TITLE
Service ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
 acl:add <app> <user>      Allow <user> to access <app>
 acl:list <app>            Show list of users with access to <app>
 acl:remove <app> <user>   Revoke <user>'s access to <app>
+
+acl:add-service <type> <service> <user>      Allow <user> to access <service> of type <type>
+acl:list-service <type> <service>            Show list of users with access to <service> of type <type>
+acl:remove-service <type> <service> <user>   Revoke <user>'s access to <service> of type <type>
 ```
 
 ## usage
@@ -76,10 +80,14 @@ If defined, this user is always allowed to push, and no other users are allowed 
 
 By default, all users can run all dokku commands. To restrict the commands
 available to non-admin users, whitelist the desired commands in
-`~dokku/.dokkurc/acl`. Two lists of commands can be defined:
-commands in `$DOKKU_ACL_USER_COMMANDS` can be run by any user at any time,
-and commands in `$DOKKU_ACL_PER_APP_COMMANDS` can be run on an app by any user
+`~dokku/.dokkurc/acl`. The following lists of commands can be defined:
+* Commands in `$DOKKU_ACL_USER_COMMANDS` can be run by any user at any time
+* Commands in `$DOKKU_ACL_PER_APP_COMMANDS` can be run on an app by any user
 with permission to manage that app.
+* Commands in `$DOKKU_ACL_PER_SERVICE_COMMANDS` can be run on any service by
+any user with permission to manage that service.
+* Commands in `$DOKKU_ACL_LINK_COMMANDS` can be run by any user with permission
+to manage both the service and the app being linked.
 
 See the section on secure multi-tenancy for examples.
 

--- a/internal-functions
+++ b/internal-functions
@@ -89,3 +89,20 @@ fn-check-app-acl() {
 
   dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
 }
+
+fn-check-service-acl() {
+  declare desc="Checks if the current user has an ACL entry for the service"
+  declare CMD="$1" SERVICE="$2" SSH_NAME="$3"
+
+  local SERVICE_TYPE="${CMD%%:*}"
+  local SERVICE_PATH="$DOKKU_LIB_ROOT/services/$SERVICE_TYPE/$SERVICE"
+  local ACL_FILE="$SERVICE_PATH/acl/$SSH_NAME"
+
+  if ! [[ -d $SERVICE_PATH ]]; then
+    dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $SERVICE, or $SERVICE does not exist"
+  fi
+
+  [[ -f "$ACL_FILE" ]] && return 0
+
+  dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $SERVICE, or $SERVICE does not exist"
+}

--- a/internal-functions
+++ b/internal-functions
@@ -76,6 +76,19 @@ fn-acl-check-app() {
   fi
 }
 
+fn-acl-check-service() {
+  declare SERVICE_TYPE="$1" SERVICE="$2"
+
+  local SERVICE_PATH="$DOKKU_LIB_ROOT/services/$SERVICE_TYPE/$SERVICE"
+  if ! [[ -d $SERVICE_PATH ]]; then
+    dokku_log_fail "Service $SERVICE of type $SERVICE_TYPE does not exist"
+  fi
+
+  if [[ -n "${NAME:-}" ]]; then
+    dokku_log_fail "You can only modify ACL using local dokku command on target host"
+  fi
+}
+
 fn-check-app-acl() {
   declare desc="Checks if the current user has an ACL entry for the app"
   declare APP="$1" SSH_NAME="$2"

--- a/internal-functions
+++ b/internal-functions
@@ -75,3 +75,17 @@ fn-acl-check-app() {
     dokku_log_fail "You can only modify ACL using local dokku command on target host"
   fi
 }
+
+fn-check-app-acl() {
+  declare desc="Checks if the current user has an ACL entry for the app"
+  declare APP="$1" SSH_NAME="$2"
+  local ACL_FILE="$DOKKU_ROOT/$APP/acl/$SSH_NAME"
+
+  if ! ( verify_app_name "$APP" 2>/dev/null ); then
+    dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
+  fi
+
+  [[ -f "$ACL_FILE" ]] && return 0
+
+  dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
+}

--- a/subcommands/add-service
+++ b/subcommands/add-service
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/internal-functions"
+
+cmd-acl-add-service() {
+  #E allow the servuser user access to the birds Redis service
+  #E dokku $PLUGIN_COMMAND_PREFIX:add-service redis birds servuser
+  #A type, type of service
+  #A service, service to run command against
+  #A user, a user to allow access
+  declare desc="allow <user> to control <service> of type <type>"
+  local cmd="$PLUGIN_COMMAND_PREFIX:add-service" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare SERVICE_TYPE="$1" SERVICE="$2" USER="$3"
+
+  fn-acl-check-service "$SERVICE_TYPE" "$SERVICE"
+
+  local ACL_PATH="$DOKKU_LIB_ROOT/services/$SERVICE_TYPE/$SERVICE/acl"
+  local ACL_FILE="$ACL_PATH/$USER"
+
+  if [[ -z "$USER" ]]; then
+    dokku_log_fail "Please specify a user name"
+  fi
+
+  [[ ! -d "$ACL_PATH" ]] && mkdir -p "$ACL_PATH"
+
+  if [[ -f "$ACL_FILE" ]]; then
+     echo "User already has permissions to push to this repository" >&2
+     exit 2;
+  fi
+
+  touch "$ACL_FILE"
+}
+
+cmd-acl-add-service "$@"

--- a/subcommands/list-service
+++ b/subcommands/list-service
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/internal-functions"
+
+cmd-acl-list-service() {
+  #E show users that have access to the birds redis service
+  #E dokku $PLUGIN_COMMAND_PREFIX:list redis birds
+  #A type, type of service
+  #A service, service to run command against
+  declare desc="show list of users with access to <service> of type <type>"
+  local cmd="$PLUGIN_COMMAND_PREFIX:list-service" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare SERVICE_TYPE="$1" SERVICE="$2"
+
+  fn-acl-check-service "$SERVICE_TYPE" "$SERVICE"
+
+  local ACL_PATH="$DOKKU_LIB_ROOT/services/$SERVICE_TYPE/$SERVICE/acl"
+  ls -1 "$ACL_PATH" >&2 2>/dev/null || true
+}
+
+cmd-acl-list-service "$@"

--- a/subcommands/remove-service
+++ b/subcommands/remove-service
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/internal-functions"
+
+cmd-acl-remove-service() {
+  #E revoke the servuser user's access to the birds Redis service
+  #E dokku $PLUGIN_COMMAND_PREFIX:remove-service redis birds servuser
+  #A type, type of service
+  #A service, service to run command against
+  #A user, a user to revoke access
+  declare desc="revoke <user>'s access to <service> of type <type>"
+  local cmd="$PLUGIN_COMMAND_PREFIX:remove-service" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare SERVICE_TYPE="$1" SERVICE="$2" USER="$3"
+
+  fn-acl-check-service "$SERVICE_TYPE" "$SERVICE"
+
+  local ACL_PATH="$DOKKU_LIB_ROOT/services/$SERVICE_TYPE/$SERVICE/acl"
+  local ACL_FILE="$ACL_PATH/$USER"
+
+  if [[ -z "$USER" ]]; then
+    dokku_log_fail "Please specify a user name"
+  fi
+
+  [[ -f "$ACL_FILE" ]] && rm "$ACL_FILE";
+  [[ -d "$ACL_PATH" ]] && [[ -z "$(ls "$ACL_PATH")" ]] && rmdir "$ACL_PATH";
+}
+
+cmd-acl-remove-service "$@"

--- a/tests/commands.bats
+++ b/tests/commands.bats
@@ -7,10 +7,16 @@ HOOK="${DOKKU_ROOT:?}/plugins/${PLUGIN_COMMAND_PREFIX:?}/pre-build"
 
 setup() {
   dokku apps:create acl-test-app >&2
+  TMP=$(mktemp -d)
+  export DOKKU_LIB_ROOT="$TMP"
+  export DOKKU_LIB_PATH="$TMP"
+  SERVICE_PATH="$DOKKU_LIB_ROOT/services/redis/acl-test-service"
+  mkdir -p "$SERVICE_PATH"
 }
 
 teardown() {
   sudo -u $DOKKU_SYSTEM_USER rm -rf "${APP_DIR:?}"
+  rm -rf "$TMP"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:add) can add a user to an ACL" {
@@ -48,6 +54,38 @@ teardown() {
   dokku acl:add $APP user2
 
   run dokku acl:list $APP
+  assert_success
+  assert_equal ${lines[0]} "user1"
+  assert_equal ${lines[1]} "user2"
+}
+
+@test "($PLUGIN_COMMAND_PREFIX:add) can add a user to a service ACL" {
+  run dokku acl:add-service redis acl-test-service user1
+  assert_success
+  echo exit $?
+
+  [ -e "$SERVICE_PATH/acl/user1" ] || flunk "ACL file not created"
+}
+
+@test "($PLUGIN_COMMAND_PREFIX:remove) can remove a user from a service ACL" {
+  sudo -u "$DOKKU_SYSTEM_USER" mkdir -p "$SERVICE_PATH/acl"
+  sudo -u "$DOKKU_SYSTEM_USER" touch "$SERVICE_PATH/acl/user1"
+
+  run dokku acl:remove-service redis acl-test-service user1
+  assert_success
+
+  [ ! -e "$SERVICE_PATH/acl/user1" ] || flunk "ACL file still exists"
+}
+
+@test "($PLUGIN_COMMAND_PREFIX:list) can list users in a service ACL" {
+  dokku acl:add-service redis acl-test-service user1
+
+  run dokku acl:list-service redis acl-test-service
+  assert_success "user1"
+
+  dokku acl:add-service redis acl-test-service user2
+
+  run dokku acl:list-service redis acl-test-service
   assert_success
   assert_equal ${lines[0]} "user1"
   assert_equal ${lines[1]} "user2"

--- a/tests/hook_user_auth.bats
+++ b/tests/hook_user_auth.bats
@@ -10,15 +10,19 @@ ALLOWED_CMDS="apps:list certs:report help"
 RESTRICTED_CMDS="domains:report events ls ps:report"
 ALL_CMDS="$ALLOWED_CMDS $RESTRICTED_CMDS"
 
-# Slightly more complicated: these commands require an app name as an argument
+# Slightly more complicated: these commands require an app or service name as an argument
 PER_APP_CMDS="config logs urls"
+PER_SERVICE_CMDS="redis:info redis:stop"
 
 setup() {
   dokku apps:create acl-test-app >&2
+  TMP=$(mktemp -d)
+  export DOKKU_LIB_ROOT="$TMP"
 }
 
 teardown() {
   sudo -u $DOKKU_SYSTEM_USER rm -rf "${APP_DIR:?}"
+  rm -rf "$TMP"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:hook-user-auth) allows all commands by default" {
@@ -81,9 +85,27 @@ teardown() {
   done
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:hook-user-auth) allows per-service commands only for users in the service ACL" {
+  export DOKKU_ACL_PER_SERVICE_COMMANDS="$PER_SERVICE_CMDS"
+  local SERVICE_DIR="$DOKKU_LIB_ROOT/services/redis/acl-test-service"
+  sudo -u $DOKKU_SYSTEM_USER mkdir -p $SERVICE_DIR/acl
+  sudo -u $DOKKU_SYSTEM_USER touch $SERVICE_DIR/acl/user1
+
+  for cmd in $PER_SERVICE_CMDS; do
+    run $HOOK dokku user1 $cmd acl-test-service
+    assert_success
+  done
+
+  for cmd in $PER_SERVICE_CMDS; do
+    run $HOOK dokku user2 $cmd acl-test-service
+    assert_failure "User user2 does not have permissions to run $cmd on acl-test-service, or acl-test-service does not exist"
+  done
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:hook-user-auth) superuser and root can run any commands" {
   export DOKKU_ACL_USER_COMMANDS="$ALLOWED_CMDS"
   export DOKKU_ACL_PER_APP_COMMANDS="$PER_APP_CMDS"
+  export DOKKU_ACL_PER_SERVICE_COMMANDS="$PER_SERVICE_CMDS"
   export DOKKU_SUPER_USER=admin
 
   for cmd in $ALL_CMDS; do
@@ -96,13 +118,13 @@ teardown() {
     assert_success
   done
 
-  for cmd in $PER_APP_CMDS; do
-    run $HOOK dokku admin $cmd acl-test-app
+  for cmd in $PER_APP_CMDS $PER_SERVICE_CMDS; do
+    run $HOOK dokku admin $cmd acl-test-thing
     assert_success
   done
 
-  for cmd in $PER_APP_CMDS; do
-    run $HOOK root root $cmd acl-test-app
+  for cmd in $PER_APP_CMDS $PER_SERVICE_CMDS; do
+    run $HOOK root root $cmd acl-test-thing
     assert_success
   done
 }

--- a/tests/hook_user_auth.bats
+++ b/tests/hook_user_auth.bats
@@ -10,9 +10,10 @@ ALLOWED_CMDS="apps:list certs:report help"
 RESTRICTED_CMDS="domains:report events ls ps:report"
 ALL_CMDS="$ALLOWED_CMDS $RESTRICTED_CMDS"
 
-# Slightly more complicated: these commands require an app or service name as an argument
+# Slightly more complicated: these commands require an app and/or service name as an argument
 PER_APP_CMDS="config logs urls"
 PER_SERVICE_CMDS="redis:info redis:stop"
+LINK_CMDS="redis:link redis:unlink"
 
 setup() {
   dokku apps:create acl-test-app >&2
@@ -102,6 +103,33 @@ teardown() {
   done
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:hook-user-auth) allows link commands only for users in the service AND app ACLs" {
+  sudo -u $DOKKU_SYSTEM_USER mkdir -p $APP_DIR/acl
+  sudo -u $DOKKU_SYSTEM_USER touch $APP_DIR/acl/user1
+  sudo -u $DOKKU_SYSTEM_USER touch $APP_DIR/acl/user2
+
+  export DOKKU_ACL_LINK_COMMANDS="$LINK_CMDS"
+  local SERVICE_DIR="$DOKKU_LIB_ROOT/services/redis/acl-test-service"
+  sudo -u $DOKKU_SYSTEM_USER mkdir -p $SERVICE_DIR/acl
+  sudo -u $DOKKU_SYSTEM_USER touch $SERVICE_DIR/acl/user1
+  sudo -u $DOKKU_SYSTEM_USER touch $SERVICE_DIR/acl/user3
+
+  for cmd in $LINK_CMDS; do
+    run $HOOK dokku user1 $cmd acl-test-service acl-test-app
+    assert_success
+  done
+
+  for user in user2 user3 user4; do
+    for cmd in $LINK_CMDS; do
+      run $HOOK dokku $user $cmd acl-test-service acl-test-app
+
+      [[ "$user" = user3 ]] && type=app || type=service
+
+      assert_failure "User $user does not have permissions to run $cmd on acl-test-$type, or acl-test-$type does not exist"
+    done
+  done
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:hook-user-auth) superuser and root can run any commands" {
   export DOKKU_ACL_USER_COMMANDS="$ALLOWED_CMDS"
   export DOKKU_ACL_PER_APP_COMMANDS="$PER_APP_CMDS"
@@ -125,6 +153,16 @@ teardown() {
 
   for cmd in $PER_APP_CMDS $PER_SERVICE_CMDS; do
     run $HOOK root root $cmd acl-test-thing
+    assert_success
+  done
+
+  for cmd in $LINK_CMDS; do
+    run $HOOK dokku admin $cmd acl-test-service acl-test-app
+    assert_success
+  done
+
+  for cmd in $LINK_CMDS; do
+    run $HOOK root root $cmd acl-test-service acl-test-app
     assert_success
   done
 }

--- a/user-auth
+++ b/user-auth
@@ -10,12 +10,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/internal-functions"
 DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
 DOKKU_ACL_USER_COMMANDS="${DOKKU_ACL_USER_COMMANDS:-}"
 DOKKU_ACL_PER_APP_COMMANDS="${DOKKU_ACL_PER_APP_COMMANDS:-}"
+DOKKU_ACL_PER_SERVICE_COMMANDS="${DOKKU_ACL_PER_SERVICE_COMMANDS:-}"
 
 SSH_USER=$1
 SSH_NAME=$2
 shift 2
 
-[[ -z "$DOKKU_ACL_USER_COMMANDS" && -z "$DOKKU_ACL_PER_APP_COMMANDS" ]] && exit 0
+[[ -z "$DOKKU_ACL_USER_COMMANDS" && -z "$DOKKU_ACL_PER_APP_COMMANDS" && -z "$DOKKU_ACL_PER_SERVICE_COMMANDS" ]] && exit 0
 [[ "$SSH_USER" == "root" ]] && exit 0
 [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$SSH_NAME" == "$DOKKU_SUPER_USER" ]] && exit 0
 
@@ -32,6 +33,16 @@ for allowed in $DOKKU_ACL_PER_APP_COMMANDS; do
     fi
 
     fn-check-app-acl "$2" "$SSH_NAME" && exit 0
+  fi
+done
+
+for allowed in $DOKKU_ACL_PER_SERVICE_COMMANDS; do
+  if [[ "$CMD" == "$allowed" ]]; then
+    if [[ -z "$2" ]]; then
+      dokku_log_fail "A service name is required"
+    fi
+
+    fn-check-service-acl "$CMD" "$2" "$SSH_NAME" && exit 0
   fi
 done
 

--- a/user-auth
+++ b/user-auth
@@ -5,6 +5,7 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$(dirname "${BASH_SOURCE[0]}")/internal-functions"
 
 DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
 DOKKU_ACL_USER_COMMANDS="${DOKKU_ACL_USER_COMMANDS:-}"
@@ -30,15 +31,7 @@ for allowed in $DOKKU_ACL_PER_APP_COMMANDS; do
       dokku_log_fail "An app name is required"
     fi
 
-    APP=$2
-    if ! ( verify_app_name "$APP" 2>/dev/null ); then
-      dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
-    fi
-
-    ACL_FILE="$DOKKU_ROOT/$APP/acl/$SSH_NAME"
-    [[ -f "$ACL_FILE" ]] && exit 0
-
-    dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $APP, or $APP does not exist"
+    fn-check-app-acl "$2" "$SSH_NAME" && exit 0
   fi
 done
 

--- a/user-auth
+++ b/user-auth
@@ -11,12 +11,13 @@ DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
 DOKKU_ACL_USER_COMMANDS="${DOKKU_ACL_USER_COMMANDS:-}"
 DOKKU_ACL_PER_APP_COMMANDS="${DOKKU_ACL_PER_APP_COMMANDS:-}"
 DOKKU_ACL_PER_SERVICE_COMMANDS="${DOKKU_ACL_PER_SERVICE_COMMANDS:-}"
+DOKKU_ACL_LINK_COMMANDS="${DOKKU_ACL_LINK_COMMANDS:-}"
 
 SSH_USER=$1
 SSH_NAME=$2
 shift 2
 
-[[ -z "$DOKKU_ACL_USER_COMMANDS" && -z "$DOKKU_ACL_PER_APP_COMMANDS" && -z "$DOKKU_ACL_PER_SERVICE_COMMANDS" ]] && exit 0
+[[ -z "$DOKKU_ACL_USER_COMMANDS" && -z "$DOKKU_ACL_PER_APP_COMMANDS" && -z "$DOKKU_ACL_PER_SERVICE_COMMANDS" && -z "$DOKKU_ACL_LINK_COMMANDS" ]] && exit 0
 [[ "$SSH_USER" == "root" ]] && exit 0
 [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$SSH_NAME" == "$DOKKU_SUPER_USER" ]] && exit 0
 
@@ -43,6 +44,23 @@ for allowed in $DOKKU_ACL_PER_SERVICE_COMMANDS; do
     fi
 
     fn-check-service-acl "$CMD" "$2" "$SSH_NAME" && exit 0
+  fi
+done
+
+for allowed in $DOKKU_ACL_LINK_COMMANDS; do
+  if [[ "$CMD" == "$allowed" ]]; then
+    if [[ -z "$2" ]]; then
+      dokku_log_fail "A service name is required"
+    fi
+
+    if [[ -z "$3" ]]; then
+      dokku_log_fail "An app name is required"
+    fi
+
+    (fn-check-service-acl "$CMD" "$2" "$SSH_NAME") && (fn-check-app-acl "$3" "$SSH_NAME") && exit 0
+
+    # An appropriate failure message has already been sent by the check- function
+    exit 1
   fi
 done
 


### PR DESCRIPTION
### Design

Allow users to be added and removed from per-service ACLs:
* `dokku acl:add-service TYPE SERVICE USER`
   * `TYPE` is the service type, e.g, `redis`
* `dokku acl:list-service TYPE SERVICE`
* `dokku acl:remove-service TYPE SERVICE USER`

This would be implemented using an `acl` directory per service, similarly to what we do for apps. For example if user `jody` was added to the ACL for redis service `dredis`, we would create `/var/lib/dokku/services/redis/dredis/acl/jody`.

In keeping with the existing dokku-acl philosophy of providing a framework for ACLs rather than a specific policy, we'd define two configuration variables:
* `DOKKU_ACL_PER_SERVICE_COMMANDS`: lists the commands that can be performed on a service if the user has been added to that service's ACL (intended for commands like `redis:info`).
* `DOKKU_ACL_LINK_COMMANDS`: these commands would only be allowed if a user has access to _both_ the service and the app (intended for commands like `redis:link` and `redis:unlink`).