### PR TITLE
Add support for specifying multiple superusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ user by defining `$DOKKU_SUPER_USER` env in `~dokku/.dokkurc/acl`:
 export DOKKU_SUPER_USER=puck
 ```
 
-If defined, this user is always allowed to push, and no other users are allowed to push to apps with empty ACLs.
+If defined, this user (or users) is always allowed to push, and no other users are allowed to push to apps with empty ACLs.
+
+You can also specify multiple users:
+
+```shell
+export DOKKU_SUPER_USER="dokku puck"
+```
 
 ### command restrictions
 

--- a/internal-functions
+++ b/internal-functions
@@ -126,9 +126,11 @@ fn-acl-is-super-user() {
   declare desc="check if the specified user is a super user"
   declare USERNAME="$1"
 
-  if [[ "$USERNAME" == "$DOKKU_SUPER_USER" ]]; then
-    return
-  fi
+  for super_user in $DOKKU_SUPER_USER; do
+    if [[ "$USERNAME" == "$super_user" ]]; then
+      return
+    fi
+  done
 
   return 1
 }

--- a/pre-build
+++ b/pre-build
@@ -2,6 +2,7 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$(dirname "${BASH_SOURCE[0]}")/internal-functions"
 
 APP="$1"
 ACL="$DOKKU_ROOT/$APP/acl"
@@ -26,7 +27,7 @@ if [[ -z "$NAME" ]]; then
 fi
 
 if [[ ! -d "$ACL" ]]; then
-  if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
+  if [[ -n "$DOKKU_SUPER_USER" ]] && ! fn-acl-is-super-user "$NAME"; then
     dokku_log_fail "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty"
   fi
 
@@ -35,7 +36,7 @@ fi
 
 ACL_FILE="$ACL/$NAME"
 
-if [[ ! -f "$ACL_FILE" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
+if [[ ! -f "$ACL_FILE" ]] && ! fn-acl-is-super-user "$NAME"; then
   echo "User $NAME does not have permissions to modify this repository" >&2
   exit 2
 fi

--- a/user-auth
+++ b/user-auth
@@ -20,7 +20,7 @@ shift 2
 
 [[ -z "$DOKKU_ACL_USER_COMMANDS" && -z "$DOKKU_ACL_PER_APP_COMMANDS" && -z "$DOKKU_ACL_PER_SERVICE_COMMANDS" && -z "$DOKKU_ACL_LINK_COMMANDS" ]] && exit 0
 [[ "$SSH_USER" == "root" ]] && exit 0
-[[ -n "$DOKKU_SUPER_USER" ]] && [[ "$SSH_NAME" == "$DOKKU_SUPER_USER" ]] && exit 0
+[[ -n "$DOKKU_SUPER_USER" ]] && fn-acl-is-super-user "$SSH_NAME" && exit 0
 
 CMD=$1
 


### PR DESCRIPTION
This not only makes running commands manually much simpler, but removes some confusion around "dokku" / "default" user as the superuser (some places need both).

Fixes #22
Fixes #36

Currently untested, but should theoretically work.

I've intentionally left the variable unpluralized, so the change is completely non-breaking.

The main downside I can see, is that some places we display `$DOKKU_SUPER_USER` will just show the space-separated internal value.

This also has the benefit of reusing an internal function, rather than doing a comparison multiple times.