### PR TITLE
fix: adapt to new trigger naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ hosting. (See below for notes and limitations.)
 
 ## requirements
 
-- dokku 0.4.0+
+- dokku 0.32.0+
 - docker 1.8.x
 
 - An older version of this plugin works with dokku 0.3.x; the last version

--- a/internal-functions
+++ b/internal-functions
@@ -122,6 +122,47 @@ fn-check-service-acl() {
   dokku_log_fail "User $SSH_NAME does not have permissions to run $CMD on $SERVICE, or $SERVICE does not exist"
 }
 
+fn-check-modify-app-acl() {
+  declare desc="Checks if the current dokku user is allowed to modify the given app"
+  declare APP="$1"
+
+  local ACL="$DOKKU_ROOT/$APP/acl"
+  local DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
+  local DOKKU_ACL_ALLOW_COMMAND_LINE="${DOKKU_ACL_ALLOW_COMMAND_LINE:-}"
+
+  if [[ -z "$NAME" ]]; then
+    # Command line usage doesn't set $NAME.
+
+    if [[ -z "$DOKKU_ACL_ALLOW_COMMAND_LINE" ]]; then
+      # Preserve legacy behaviour by default for safety, even though it's weird.
+
+      [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
+
+      dokku_log_fail "It appears that you're running this command from the command" \
+        "line.  The \"dokku-acl\" plugin disables this by default for" \
+        "safety.  Please check the \"dokku-acl\" documentation for how" \
+        "to enable command line usage."
+    fi
+
+    exit 0
+  fi
+
+  if [[ ! -d "$ACL" ]]; then
+    if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
+      dokku_log_fail "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty"
+    fi
+
+    exit 0 # all good, there are no restrictions
+  fi
+
+  local ACL_FILE="$ACL/$NAME"
+
+  if [[ ! -f "$ACL_FILE" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
+    echo "User $NAME does not have permissions to modify this repository" >&2
+    exit 2
+  fi
+}
+
 fn-acl-is-super-user() {
   declare desc="check if the specified user is a super user"
   declare USERNAME="$1"

--- a/pre-build
+++ b/pre-build
@@ -3,7 +3,7 @@ set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
-APP="$1"
+APP="$2"
 ACL="$DOKKU_ROOT/$APP/acl"
 DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
 DOKKU_ACL_ALLOW_COMMAND_LINE="${DOKKU_ACL_ALLOW_COMMAND_LINE:-}"

--- a/pre-build
+++ b/pre-build
@@ -2,40 +2,7 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$(dirname "${BASH_SOURCE[0]}")/internal-functions"
 
 APP="$2"
-ACL="$DOKKU_ROOT/$APP/acl"
-DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
-DOKKU_ACL_ALLOW_COMMAND_LINE="${DOKKU_ACL_ALLOW_COMMAND_LINE:-}"
-
-if [[ -z "$NAME" ]]; then
-  # Command line usage doesn't set $NAME.
-
-  if [[ -z "$DOKKU_ACL_ALLOW_COMMAND_LINE" ]]; then
-    # Preserve legacy behaviour by default for safety, even though it's weird.
-
-    [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
-
-    dokku_log_fail "It appears that you're running this command from the command" \
-      "line.  The \"dokku-acl\" plugin disables this by default for" \
-      "safety.  Please check the \"dokku-acl\" documentation for how" \
-      "to enable command line usage."
-  fi
-
-  exit 0
-fi
-
-if [[ ! -d "$ACL" ]]; then
-  if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-    dokku_log_fail "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty"
-  fi
-
-  exit 0 # all good, there are no restrictions
-fi
-
-ACL_FILE="$ACL/$NAME"
-
-if [[ ! -f "$ACL_FILE" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-  echo "User $NAME does not have permissions to modify this repository" >&2
-  exit 2
-fi
+fn-check-modify-app-acl "$APP"

--- a/pre-build-buildstep
+++ b/pre-build-buildstep
@@ -1,1 +1,0 @@
-pre-build

--- a/pre-delete
+++ b/pre-delete
@@ -2,40 +2,7 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$(dirname "${BASH_SOURCE[0]}")/internal-functions"
 
 APP="$1"
-ACL="$DOKKU_ROOT/$APP/acl"
-DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
-DOKKU_ACL_ALLOW_COMMAND_LINE="${DOKKU_ACL_ALLOW_COMMAND_LINE:-}"
-
-if [[ -z "$NAME" ]]; then
-  # Command line usage doesn't set $NAME.
-
-  if [[ -z "$DOKKU_ACL_ALLOW_COMMAND_LINE" ]]; then
-    # Preserve legacy behaviour by default for safety, even though it's weird.
-
-    [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
-
-    dokku_log_fail "It appears that you're running this command from the command" \
-      "line.  The \"dokku-acl\" plugin disables this by default for" \
-      "safety.  Please check the \"dokku-acl\" documentation for how" \
-      "to enable command line usage."
-  fi
-
-  exit 0
-fi
-
-if [[ ! -d "$ACL" ]]; then
-  if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-    dokku_log_fail "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty"
-  fi
-
-  exit 0 # all good, there are no restrictions
-fi
-
-ACL_FILE="$ACL/$NAME"
-
-if [[ ! -f "$ACL_FILE" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
-  echo "User $NAME does not have permissions to modify this repository" >&2
-  exit 2
-fi
+fn-check-modify-app-acl "$APP"

--- a/pre-delete
+++ b/pre-delete
@@ -1,1 +1,41 @@
-pre-build
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+APP="$1"
+ACL="$DOKKU_ROOT/$APP/acl"
+DOKKU_SUPER_USER="${DOKKU_SUPER_USER:-}"
+DOKKU_ACL_ALLOW_COMMAND_LINE="${DOKKU_ACL_ALLOW_COMMAND_LINE:-}"
+
+if [[ -z "$NAME" ]]; then
+  # Command line usage doesn't set $NAME.
+
+  if [[ -z "$DOKKU_ACL_ALLOW_COMMAND_LINE" ]]; then
+    # Preserve legacy behaviour by default for safety, even though it's weird.
+
+    [[ -z "$DOKKU_SUPER_USER" ]] && exit 0
+
+    dokku_log_fail "It appears that you're running this command from the command" \
+      "line.  The \"dokku-acl\" plugin disables this by default for" \
+      "safety.  Please check the \"dokku-acl\" documentation for how" \
+      "to enable command line usage."
+  fi
+
+  exit 0
+fi
+
+if [[ ! -d "$ACL" ]]; then
+  if [[ -n "$DOKKU_SUPER_USER" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
+    dokku_log_fail "Only $DOKKU_SUPER_USER can modify a repository if the ACL is empty"
+  fi
+
+  exit 0 # all good, there are no restrictions
+fi
+
+ACL_FILE="$ACL/$NAME"
+
+if [[ ! -f "$ACL_FILE" ]] && [[ "$NAME" != "$DOKKU_SUPER_USER" ]]; then
+  echo "User $NAME does not have permissions to modify this repository" >&2
+  exit 2
+fi

--- a/pre-receive-app
+++ b/pre-receive-app
@@ -1,1 +1,1 @@
-pre-build
+pre-delete


### PR DESCRIPTION
[Dokku v0.32.0](https://github.com/dokku/dokku/releases/tag/v0.32.0) deprecates `pre-build-*` triggers in favor of a global pre-build trigger.
The refactoring also introduced a name collision in `dokku-acl`, leading to falsely aborted build processes.
This commit updates the plugin to use the new plugin trigger.

I tested this code with `make lint`, and it introduced no errors that haven't been present before.
Unfortunately, I couldn't run the bats unit tests as I'm having trouble setting up the dokku vagrant VM. However, I have confirmed the plugin behaves correctly when deploying to an ACL-protected app.